### PR TITLE
Allows configuring Faraday proxy

### DIFF
--- a/lib/paddle_pay/configuration.rb
+++ b/lib/paddle_pay/configuration.rb
@@ -3,6 +3,9 @@
 module PaddlePay
   class Configuration
     attr_reader :environment
+    attr_accessor :proxy_host
+    attr_accessor :proxy_port
+    attr_accessor :ssl_verify
     attr_accessor :vendor_auth_code
     attr_accessor :vendor_id
 

--- a/lib/paddle_pay/connection.rb
+++ b/lib/paddle_pay/connection.rb
@@ -9,7 +9,9 @@ module PaddlePay
         headers = options.delete(:headers) || {}
         body = options.delete(:body) || {}
 
-        conn = Faraday.new(url: request_url) { |faraday|
+        conn = Faraday.new(url: request_url,
+                           proxy: proxy_url,
+                           ssl: { verify: PaddlePay.config.ssl_verify }) { |faraday|
           faraday.request :url_encoded
           faraday.response :raise_error
           faraday.response :json
@@ -61,6 +63,14 @@ module PaddlePay
           vendor_id: PaddlePay.config.vendor_id,
           vendor_auth_code: PaddlePay.config.vendor_auth_code
         }
+      end
+
+      def proxy_url
+        if PaddlePay.config.proxy_host && PaddlePay.config.proxy_port
+          return "#{PaddlePay.config.proxy_host}:#{PaddlePay.config.proxy_port}"
+        end
+
+        nil
       end
     end
   end


### PR DESCRIPTION
This PR allows one to configure a proxy through which the faraday requests will go to.

In my case, I'm using this to mock calls to the Paddle APIs from my test suite.